### PR TITLE
Now Using WP Provisioner

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -67,7 +67,7 @@ Vagrant.configure("2") do |config|
         s.privileged = false
         s.inline = <<-SHELL
             echo "Updating Composer"
-            composer self-update
+            sudo composer self-update
 
             echo -n 'Checking for WP CLI... '
             if [ ! -f "#{path_wp_cli}" ]; then
@@ -75,7 +75,7 @@ Vagrant.configure("2") do |config|
                 cd "/tmp" && sudo wget -q "#{url_wpcli}" && sudo chmod +x "/tmp/wp-cli.phar" && sudo mv "/tmp/wp-cli.phar" "#{path_wp_cli}"
             else
                 echo ' found! Updating'
-                #{path_wp_cli} cli update --allow-root --yes
+                sudo #{path_wp_cli} cli update --allow-root --yes
             fi
 
             echo -n 'Checking for Bedrock... '

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,7 +39,7 @@ Vagrant.configure("2") do |config|
     url_wordpress = "http://#{name_realhost}"
 
     # WP Provisioner dependency Composer package name
-    dep_wp_provisioner = "dnaber/wp-provisioner"
+    dep_wp_provisioner = "dhii/wp-provisioner:0.1-alpha"
 
     db_name = "scotchbox"
     db_user = "root"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,7 +59,7 @@ Vagrant.configure("2") do |config|
     config.vm.hostname = hostname
     config.vm.box = "scotch/box"
     config.hostsupdater.aliases = ["www.#{name_realhost}","#{name_realhost}"]
-    config.vm.synced_folder ".", "#{path_apache_www}", :mount_options => ["dmode=777", "fmode=766"], group: "vagrant"
+    config.vm.synced_folder ".", "#{path_apache_www}", :mount_options => ["dmode=777", "fmode=766"]
 
     # Optional NFS. Make sure to remove other synced_folder line too
     #config.vm.synced_folder ".", "#{path_apache_www}", :nfs => { :mount_options => ["dmode=777","fmode=666"] }
@@ -128,7 +128,7 @@ Vagrant.configure("2") do |config|
                 printf "DB_NAME=#{db_name}\nDB_USER=#{db_user}\nDB_PASSWORD=#{db_password}\nDB_HOST=#{db_host}\nWP_ENV=development\nWP_HOME=http://#{name_realhost}\nWP_SITEURL=http://#{name_realhost}/wp" > "#{path_project_root}/.env"
                 echo "Installing WordPress"
                 /home/vagrant/.rbenv/shims/mailcatcher --http-ip=0.0.0.0
-                cd "#{path_abs_docroot}"
+                cd "#{path_project_root}"
                 # Provisioning WordPress
                 "#{path_wp_provisioner}" provision 0.1.0
                 echo 'WordPress installation finished!'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,6 +36,9 @@ Vagrant.configure("2") do |config|
     url_bedrock = "https://github.com/roots/bedrock.git"
     url_wordpress = "http://#{name_realhost}"
 
+    # WP Provisioner dependency Composer package name
+    dep_wp_provisioner = "dnaber/wp-provisioner"
+
     db_name = "scotchbox"
     db_user = "root"
     db_password = "root"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -145,7 +145,7 @@ Vagrant.configure("2") do |config|
 
     config.vm.provider :virtualbox do |vb|
 		    vb.gui = false
-		    vb.memory = 2048
+		    vb.memory = 1024
         vb.name = hostname
         vb.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
         vb.customize ['modifyvm', :id, '--natdnsproxy1', 'on']

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,7 +59,7 @@ Vagrant.configure("2") do |config|
     config.vm.hostname = hostname
     config.vm.box = "scotch/box"
     config.hostsupdater.aliases = ["www.#{name_realhost}","#{name_realhost}"]
-    config.vm.synced_folder ".", "#{path_apache_www}", :mount_options => ["dmode=777", "fmode=666"]
+    config.vm.synced_folder ".", "#{path_apache_www}", :mount_options => ["dmode=777", "fmode=766"], group: "vagrant"
 
     # Optional NFS. Make sure to remove other synced_folder line too
     #config.vm.synced_folder ".", "#{path_apache_www}", :nfs => { :mount_options => ["dmode=777","fmode=666"] }

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -90,7 +90,7 @@ Vagrant.configure("2") do |config|
 
         echo "Downloading dependencies"
         export COMPOSER_CACHE_DIR="#{path_composer_cache}"
-        cd "#{path_project_root}" && composer install --prefer-dist
+        cd "#{path_project_root}" && composer require #{dep_wp_provisioner} && composer install --prefer-dist
 
         echo -n 'Checking for virtual host... '
         if [ ! -f "#{path_apache_conf}"  ]; then

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -90,7 +90,9 @@ Vagrant.configure("2") do |config|
 
         echo "Downloading dependencies"
         export COMPOSER_CACHE_DIR="#{path_composer_cache}"
-        cd "#{path_project_root}" && composer require #{dep_wp_provisioner} && composer install --prefer-dist
+        cd "#{path_project_root}"
+        composer config minimum-stability dev
+        composer install --prefer-dist && composer require #{dep_wp_provisioner}
 
         echo -n 'Checking for virtual host... '
         if [ ! -f "#{path_apache_conf}"  ]; then

--- a/provision.php
+++ b/provision.php
@@ -9,8 +9,6 @@ $siteAdminUser     = getenv('DSBR_SITE_ADMIN_USER');
 $siteAdminPassword = getenv('DSBR_SITE_ADMIN_PASSWORD');
 $siteAdminEmail    = getenv('DSBR_SITE_ADMIN_EMAIL');
 
-phpinfo(INFO_ENVIRONMENT);
-
 /**
  * The variable $api points to an instance of WpProvisioner that gives
  * you access to the public API

--- a/provision.php
+++ b/provision.php
@@ -4,6 +4,7 @@
 namespace WpProvision\Api;
 
 $projectDocroot    = getenv('DSBR_PROJECT_DOCROOT');
+$siteTitle         = getenv('DSBR_SITE_TITLE');
 $siteUrl           = getenv('DSBR_SITE_URL');
 $siteAdminUser     = getenv('DSBR_SITE_ADMIN_USER');
 $siteAdminPassword = getenv('DSBR_SITE_ADMIN_PASSWORD');
@@ -36,6 +37,9 @@ $api->versionList()->addProvision('0.1.0',
                 'login'         => $siteAdminUser,
                 'email'         => $siteAdminEmail,
                 'password'      => $siteAdminPassword
+            ],
+            [
+                'title'         => $siteTitle
             ]
         );
 

--- a/provision.php
+++ b/provision.php
@@ -1,0 +1,47 @@
+<?php
+# -*- coding: utf-8 -*-
+
+namespace WpProvision\Api;
+
+$projectDocroot    = getenv('DSBR_PROJECT_DOCROOT');
+$siteUrl           = getenv('DSBR_SITE_URL');
+$siteAdminUser     = getenv('DSBR_SITE_ADMIN_USER');
+$siteAdminPassword = getenv('DSBR_SITE_ADMIN_PASSWORD');
+$siteAdminEmail    = getenv('DSBR_SITE_ADMIN_EMAIL');
+
+phpinfo(INFO_ENVIRONMENT);
+
+/**
+ * The variable $api points to an instance of WpProvisioner that gives
+ * you access to the public API
+ *
+ * @var \WpProvision\Api\WpProvisioner $api
+ */
+
+// set the WordPess install directory. This is important for WP-CLI to run properly
+$api->setWpDir($projectDocroot);
+
+// add a provision routine named '0.1.0'. The VersionList contains all provision routines for all versions
+$api->versionList()->addProvision('0.1.0',
+    /**
+     * The command provider gives you access to all Wp Commands like core, site, user or plugin
+     *
+     * @param \WpProvision\Api\WpCommandProvider $provider
+     */
+    function($provider) use (
+        $siteUrl, $siteAdminEmail, $siteAdminUser, $siteAdminPassword
+    ) {
+
+        $provider->core()->install(
+            $siteUrl,
+            [
+                'login'         => $siteAdminUser,
+                'email'         => $siteAdminEmail,
+                'password'      => $siteAdminPassword
+            ]
+        );
+
+        $provider->plugin()->activate([
+        ]);
+    }
+);

--- a/provision.php
+++ b/provision.php
@@ -1,8 +1,6 @@
 <?php
 # -*- coding: utf-8 -*-
 
-namespace WpProvision\Api;
-
 $projectDocroot    = getenv('DSBR_PROJECT_DOCROOT');
 $siteTitle         = getenv('DSBR_SITE_TITLE');
 $siteUrl           = getenv('DSBR_SITE_URL');

--- a/provision.php
+++ b/provision.php
@@ -28,7 +28,7 @@ $api->versionList()->addProvision('0.1.0',
      * @param \WpProvision\Api\WpCommandProvider $provider
      */
     function($provider) use (
-        $siteUrl, $siteAdminEmail, $siteAdminUser, $siteAdminPassword
+        $siteUrl, $siteTitle, $siteAdminEmail, $siteAdminUser, $siteAdminPassword
     ) {
 
         $provider->core()->install(


### PR DESCRIPTION
Aims to incorporate solution for and close #12.

- Now using [WP Provisioner](https://github.com/dnaber-de/wp-provisioner);
- All files in shared folder now executable (required to run binaries);
- Minimum stability of the project is now `dev`;
- Provisioning no longer made in privileged mode, and all belongs to `vagrant`;
- Site title is now the base hostname;
